### PR TITLE
fix(package): remove ES module and Closure Compiler for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --save responsive-lazyload
 Load the module and initialize lazyloading in your app's script:
 
 ```js
-import { lazyLoadImages } from 'responsive-lazyload';
+import lazyLoadImages from 'responsive-lazyload';
 
 lazyLoadImages();
 ```
@@ -157,7 +157,7 @@ To ensure that an image is still visible, even if JavaScript is disabled, add a 
 To enable lazyloading, add the following to your initialization script:
 
 ```js
-import { lazyLoadImages } from './utils/lazyload-images';
+import lazyLoadImages from 'responsive-lazyload';
 
 lazyLoadImages({
     containerClass: 'js--lazyload',

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ npm install --save responsive-lazyload
 Load the module and initialize lazyloading in your app's script:
 
 ```js
-import lazyLoadImages from 'responsive-lazyload';
+import responsiveLazyload from 'responsive-lazyload';
 
-lazyLoadImages();
+responsiveLazyload();
 ```
 
 #### 3. Include the stylesheet.
@@ -82,7 +82,7 @@ The initialization function is stored inside a global object called `responsiveL
 
 ```html
 <script>
-  responsiveLazyload.lazyLoadImages();
+  responsiveLazyload();
 </script>
 ```
 
@@ -120,11 +120,11 @@ The markup to implement this is:
 
 ### Markup Details
 
-- The classes can be changed, but must be updated in the call to `lazyLoadImages()`.
+- The classes can be changed, but must be updated in the call to `responsiveLazyload()`.
 - The initial `srcset` is a blank GIF, which avoids an unnecessary HTTP request.
 - The _actual_ `srcset` is added as `data-lazyload`.
 
-The way `lazyLoadImages()` works is to check if the image is inside the viewport, and — if so — swap out the `srcset` for the `data-lazyload`. This is much simpler than duplicating browser behavior to choose the optimal image size; instead, we just give the browser a `srcset` and let it do its thing.
+The way `responsiveLazyload()` works is to check if the image is inside the viewport, and — if so — swap out the `srcset` for the `data-lazyload`. This is much simpler than duplicating browser behavior to choose the optimal image size; instead, we just give the browser a `srcset` and let it do its thing.
 
 On browsers that don’t support `srcset`, the regular `src` attribute is used, so this should degrade gracefully.
 
@@ -157,9 +157,9 @@ To ensure that an image is still visible, even if JavaScript is disabled, add a 
 To enable lazyloading, add the following to your initialization script:
 
 ```js
-import lazyLoadImages from 'responsive-lazyload';
+import responsiveLazyload from 'responsive-lazyload';
 
-lazyLoadImages({
+responsiveLazyload({
     containerClass: 'js--lazyload',
     loadingClass: 'js--lazyload--loading',
     callback: () => {},

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
 
     <pre>&#x3C;script src=&#x22;path/to/bower_components/responsive-lazyload/dist/responsive-lazyload.min.js&#x22;&#x3E;&#x3C;/script&#x3E;
 &#x3C;script&#x3E;
-  responsiveLazyload.lazyLoadImages();
+  responsiveLazyload();
 &#x3C;/script&#x3E;</pre>
 
     <h2>Use with <code>figure</code> elements and other wrappers.</h2>
@@ -207,7 +207,7 @@
     </p>
     <p>
       To make this happen, pass a callback to the JS function that shows or hides elements that is
-      the return value from <code>lazyLoadImages()</code>:
+      the return value from <code>responsiveLazyload()</code>:
     </p>
     <pre>&lt;script&gt;
     /*
@@ -215,7 +215,7 @@
      * to force a check for new images. This is useful when
      * images are shown/hidden by JavaScript.
      */
-    var loadVisibleImages = responsiveLazyload.lazyLoadImages();
+    var loadVisibleImages = responsiveLazyload();
 
     // THIS JS FOR THE DEMO ONLY
     window.initTabs({
@@ -243,13 +243,13 @@
   <!-- This example script initializes the tabbed example -->
   <script src="js/example-only.js"></script>
 
-  <script src="dist/responsive-lazyload.es2015.js"></script>
+  <script src="dist/responsive-lazyload.umd.js"></script>
   <script>
     /*
      * The initialization returns a function that we can call to force a check for new images. This
      * is useful when images are shown/hidden by JavaScript.
      */
-    var loadVisibleImages = responsiveLazyload.lazyLoadImages();
+    var loadVisibleImages = responsiveLazyload();
 
     // THIS JS FOR THE DEMO ONLY
     window.initTabs({

--- a/docs/loading-animation.html
+++ b/docs/loading-animation.html
@@ -134,7 +134,7 @@
 
     <pre>&#x3C;script src=&#x22;path/to/bower_components/responsive-lazyload/dist/responsive-lazyload.min.js&#x22;&#x3E;&#x3C;/script&#x3E;
 &#x3C;script&#x3E;
-  responsiveLazyload.lazyLoadImages();
+  responsiveLazyload();
 &#x3C;/script&#x3E;</pre>
 
     <h2>Use with <code>figure</code> elements and other wrappers.</h2>
@@ -274,7 +274,7 @@
     </p>
     <p>
       To make this happen, pass a callback to the JS function that shows or hides elements that is
-      the return value from <code>lazyLoadImages()</code>:
+      the return value from <code>responsiveLazyload()</code>:
     </p>
     <pre>&lt;script&gt;
     /*
@@ -282,7 +282,7 @@
      * to force a check for new images. This is useful when
      * images are shown/hidden by JavaScript.
      */
-    var loadVisibleImages = responsiveLazyload.lazyLoadImages();
+    var loadVisibleImages = responsiveLazyload();
 
     // THIS JS FOR THE DEMO ONLY
     window.initTabs({
@@ -310,13 +310,13 @@
   <!-- This example script initializes the tabbed example -->
   <script src="js/example-only.js"></script>
 
-  <script src="dist/responsive-lazyload.es2015.js"></script>
+  <script src="dist/responsive-lazyload.umd.js"></script>
   <script>
     /*
      * The initialization returns a function that we can call to force a check for new images. This
      * is useful when images are shown/hidden by JavaScript.
      */
-    var loadVisibleImages = responsiveLazyload.lazyLoadImages();
+    var loadVisibleImages = responsiveLazyload();
 
     // THIS JS FOR THE DEMO ONLY
     window.initTabs({

--- a/docs/noscript-fallback.html
+++ b/docs/noscript-fallback.html
@@ -98,7 +98,7 @@
 
     <pre>&#x3C;script src=&#x22;path/to/bower_components/responsive-lazyload/dist/responsive-lazyload.min.js&#x22;&#x3E;&#x3C;/script&#x3E;
 &#x3C;script&#x3E;
-  responsiveLazyload.lazyLoadImages();
+  responsiveLazyload();
 &#x3C;/script&#x3E;</pre>
 
     <h2>Use with <code>figure</code> elements and other wrappers.</h2>
@@ -268,9 +268,9 @@
   <a href="https://github.com/jlengstorf/responsive-lazyload.js"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 
 
-  <script src="dist/responsive-lazyload.es2015.js"></script>
+  <script src="dist/responsive-lazyload.umd.js"></script>
   <script>
-    responsiveLazyload.lazyLoadImages();
+    responsiveLazyload();
 
     // Remove the `no-js` class to signify that JS is enabled.
     document.querySelector('body').classList.remove('no-js');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "version": "1.0.3",
   "description": "A tool to lazyload images in a responsive, lightweight way (with fallbacks for unsupported browsers).",
   "main": "dist/responsive-lazyload.umd.js",
-  "module": "dist/responsive-lazyload.es2015.js",
   "files": [
     "dist/"
   ],
@@ -18,7 +17,7 @@
     "prescripts": "del dist/**/*{.js,.map}",
     "scripts:es2015": "rollup -c",
     "scripts:umd": "rollup -c rollup.config.node.js",
-    "scripts": "npm run scripts:es2015 && npm run scripts:umd",
+    "scripts": "npm run scripts:umd",
     "scripts:watch": "watch 'npm run scripts' source/scripts/",
     "prestyles": "del dist/**/*.css",
     "styles": "cssmin source/styles/responsive-lazyload.css > dist/responsive-lazyload.min.css",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,9 @@
 import babel from 'rollup-plugin-babel'; // eslint-disable-line
-import closure from 'rollup-plugin-closure-compiler-js'; //eslint-disable-line
 
 export default {
   entry: 'source/scripts/responsive-lazyload.js',
   dest: 'dist/responsive-lazyload.es2015.js',
   moduleName: 'responsiveLazyload',
-  exports: 'named',
   format: 'iife',
   sourceMap: true,
   plugins: [
@@ -14,6 +12,5 @@ export default {
       babelrc: false,
       presets: [['es2015', { modules: false }]],
     }),
-    closure(),
   ],
 };

--- a/source/scripts/responsive-lazyload.js
+++ b/source/scripts/responsive-lazyload.js
@@ -182,7 +182,7 @@ const initialize = ({
  * @param  {Object} config configuration options (see `initialize()`)
  * @return {Function}      a function to manually check for images to lazy load
  */
-export function lazyLoadImages(config = {}) {
+function lazyLoadImages(config = {}) {
   // If we have `srcset` support, initialize the lazyloader.
   /* istanbul ignore else: unreasonable to test browser support just for a no-op */
   if ('srcset' in document.createElement('img')) {
@@ -194,6 +194,4 @@ export function lazyLoadImages(config = {}) {
   return () => { /* no-op */ };
 }
 
-export default {
-  lazyLoadImages,
-};
+export default lazyLoadImages;

--- a/source/scripts/responsive-lazyload.test.js
+++ b/source/scripts/responsive-lazyload.test.js
@@ -1,4 +1,4 @@
-import { lazyLoadImages } from './responsive-lazyload';
+import lazyLoadImages from './responsive-lazyload';
 
 // We simulate the load event to ensure we’re handling it properly.
 const loadEvent = new Event('load');


### PR DESCRIPTION
Until I can figure out why it’s exporting an empty object, just disable it. UMD is working, so fuck it.